### PR TITLE
Fixes bug where child elements all being false still includes object key in className

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classcat",
   "description": "0.3 KB JavaScript function for conditionally concatenating CSS class names.",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "main": "dist/classcat.js",
   "jsnext:main": "src/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -3,25 +3,26 @@ export default function cc(classes, prefix) {
   var className = ""
   var type = typeof classes
 
+  prefix = prefix || ""
+
+  if (type === "boolean") {
+    return classes ? prefix : ""
+  }
+
   if ((classes && type === "string") || type === "number") {
     return classes
   }
 
-  prefix = prefix || " "
-
   if (Array.isArray(classes) && classes.length) {
     for (var i = 0, len = classes.length; i < len; i++) {
       if ((value = cc(classes[i], prefix))) {
-        className += (className && prefix) + value
+        className += (className && " ") + prefix + value
       }
     }
   } else {
     for (var i in classes) {
       if (classes.hasOwnProperty(i) && (value = classes[i])) {
-        className +=
-          (className && prefix) +
-          i +
-          (typeof value === "object" ? cc(value, prefix + i) : "")
+        className += (className && " ") + cc(value, prefix + i)
       }
     }
   }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -43,9 +43,9 @@ test("prefix", () => {
         quux: false,
         baz: true
       },
-      "-"
+      "prefix-"
     )
-  ).toBe("foo-bar-baz")
+  ).toBe("prefix-foo prefix-bar prefix-baz")
 })
 
 test("deep", () => {
@@ -71,4 +71,16 @@ test("not owned props", () => {
   expect(cc({})).toBe("")
 
   delete Object.prototype.myFunction
+})
+
+test("all child elements false", () => {
+  expect(
+    cc([
+      {
+        foo: {
+          "--bar": false
+        }
+      }
+    ])
+  ).toBe("")
 })


### PR DESCRIPTION
Fixes https://github.com/JorgeBucaran/classcat/issues/13

Also refactors/simplifies the logic to force space (" ") to be the separator, and no longer use `prefix` as both separator and prefix.  This breaks the original "prefix" test, which I've updated to reflect the new functionality.  Because this is a breaking change, a major version bump is required.