### PR TITLE
Adjust for API differences in bench code

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -5,7 +5,7 @@ const cc = require("../")
 require("./fixtures").map((fixed, index, { length }) => {
   const suite = new Suite()
   suite
-    .add(`Classcat – ${fixed.description}`, () => cc.apply({}, fixed.args))
+    .add(`Classcat – ${fixed.description}`, fixed.args.length > 1 ? () => cc(fixed.args) : () => cc(fixed.args[0]))
     .add(`classNames – ${fixed.description}`, () => cx.apply({}, fixed.args))
     .on("cycle", ({ target: { name, hz, stats } }) =>
       console.log(`${name} × ${Math.floor(hz).toLocaleString()} ops/sec`)

--- a/bench/index.js
+++ b/bench/index.js
@@ -4,9 +4,11 @@ const cc = require("../")
 
 require("./fixtures").map((fixed, index, { length }) => {
   const suite = new Suite()
+  const args = fixed.args.length > 1 ? fixed.args : fixed.args[0];
+
   suite
-    .add(`Classcat – ${fixed.description}`, fixed.args.length > 1 ? () => cc(fixed.args) : () => cc(fixed.args[0]))
-    .add(`classNames – ${fixed.description}`, () => cx.apply({}, fixed.args))
+    .add(`Classcat – ${fixed.description}`, () => cc(args))
+    .add(`classNames – ${fixed.description}`, fixed.args.length > 1 ? () => cx.apply(null, args) : () => cx(args))
     .on("cycle", ({ target: { name, hz, stats } }) =>
       console.log(`${name} × ${Math.floor(hz).toLocaleString()} ops/sec`)
     )


### PR DESCRIPTION
Benchmark code wrongly applies fixture args on ```classcat```. That causes the actual call to be:
e.g. for ```["one", "two", "three"]```, it currently benchmarks:
```javascript
cc("one", "two", "three");
```
instead of:
```javascript
cc(["one", "two", "three"])
```
This means the benchmark compares different work parameters for ```classcat``` and ```classNames```.
Furthermore,  as far as I can tell, ```Benchmark.Suite()``` does not validate function output. The ```expected``` value under ./bench/fixtures.js is ignored that's why this error was easy to miss.

**This PR adjusts benchmark code to make comparison fair for both functions.**

Although ```classcat``` is still faster than ```classNames```,  it is not 5x times faster. The old *Strings & Objects* benchmark giving such an impossible result should have been a red flag.

### New results
*Node 9.4.0 on an AMD Ryzen 1500X*

~~Old Classcat – Strings × 17,286,017 ops/sec~~
Actual Classcat – Strings × 7,947,812 ops/sec
classNames – Strings × 4,261,603 ops/sec
~~Fastest is Old Classcat – Strings~~
Fastest is Actual Classcat – Strings

~~Old Classcat – Objects × 5,754,260 ops/sec~~
Actual Classcat – Objects × 7,158,794 ops/sec
classNames – Objects × 3,634,329 ops/sec
Fastest is Actual Classcat – Objects

~~Old Classcat – Strings & Objects × 16,294,161 ops/sec~~
Actual Classcat – Strings & Objects × 4,732,941 ops/sec
classNames – Strings & Objects × 3,325,816 ops/sec
~~Fastest is Old Classcat – Strings & Objects~~
Fastest is Actual Classcat – Strings & Objects

~~Old Classcat – Mixed × 7,319,186 ops/sec~~
Actual Classcat – Mixed × 2,645,379 ops/sec
classNames – Mixed × 2,356,888 ops/sec
~~Fastest is Old Classcat – Mixed~~
Fastest is Actual Classcat – Mixed

~~Old Classcat – Arrays × 2,007,313 ops/sec~~
Actual Classcat – Arrays × 2,254,936 ops/sec
classNames – Arrays × 912,869 ops/sec
Fastest is Actual Classcat – Arrays