### PR TITLE
Use an explicit buffer?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,23 @@
-export default function cc(classes) {
-  var out = ""
+var buffer = []
+export default function cc(classes, nested) {
+  if (!nested) {
+    buffer.length = 0
+    cc(classes, true)
+    return buffer.join(" ")
+  }
   var type = typeof classes
 
   if (type === "string" || type === "number") {
-    return classes || ""
-  }
-
-  if (Array.isArray(classes) && classes.length > 0) {
-    for (var i = 0, len = classes.length; i < len; i++) {
-      var next = cc(classes[i])
-      if (next) {
-        out += (out && " ") + next
-      }
+    if (classes) buffer.push(classes)
+  } else if (Array.isArray(classes)) {
+    for (var i = 0; i < classes.length; i++) {
+      cc(classes[i], true)
     }
   } else {
     for (var key in classes) {
       if (classes.hasOwnProperty(key) && classes[key]) {
-        out += (out && " ") + key
+        buffer.push(key)
       }
     }
   }
-
-  return out
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -34,6 +34,17 @@ test("mixed", () => {
   ).toBe("foo foo-bar foo-baz")
 })
 
+test("nested", () => {
+  const baz = "baz"
+  expect(
+    cc([
+      ["foo"],
+      ["foo-bar", [], ["foo-baz"]],
+    ])
+  ).toBe("foo foo-bar foo-baz")
+})
+
+
 test("not owned props", () => {
   Object.prototype.myFunction = () => {}
 


### PR DESCRIPTION
There's a perf penalty for the simplest case, and benefits for the most complex ones. The code size doesn't move. The resulting string is also flat vs probably a tree-like rope for what the current version produces. The latter could be slower to parse by the DOM api (that overhead is not currently benchmarked).

Before:

```
Classcat – Strings × 6,655,176 ops/sec
classNames – Strings × 2,773,836 ops/sec
Fastest is Classcat – Strings

Classcat – Objects × 4,805,586 ops/sec
classNames – Objects × 2,317,781 ops/sec
Fastest is Classcat – Objects

Classcat – Strings & Objects × 4,259,464 ops/sec
classNames – Strings & Objects × 2,129,470 ops/sec
Fastest is Classcat – Strings & Objects

Classcat – Mixed × 2,571,844 ops/sec
classNames – Mixed × 1,564,550 ops/sec
Fastest is Classcat – Mixed

Classcat – Arrays × 2,082,569 ops/sec
classNames – Arrays × 669,301 ops/sec
Fastest is Classcat – Arrays
```

After:

```
Classcat – Strings × 5,564,369 ops/sec
classNames – Strings × 2,688,253 ops/sec
Fastest is Classcat – Strings

Classcat – Objects × 5,670,332 ops/sec
classNames – Objects × 2,343,242 ops/sec
Fastest is Classcat – Objects

Classcat – Strings & Objects × 5,375,772 ops/sec
classNames – Strings & Objects × 2,150,893 ops/sec
Fastest is Classcat – Strings & Objects

Classcat – Mixed × 5,521,760 ops/sec
classNames – Mixed × 1,553,639 ops/sec
Fastest is Classcat – Mixed

Classcat – Arrays × 5,573,590 ops/sec
classNames – Arrays × 585,414 ops/sec
Fastest is Classcat – Arrays
```