### PR TITLE
Speedup by reorganizing code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,27 @@
 export default function cc(classes) {
   var out = ""
-  var type = typeof classes
 
-  if (type === "string" || type === "number") {
-    return classes || ""
-  }
+  if (Array.isArray(classes)) {
+    if (classes.length > 1) {
+      for (var i = 0, len = classes.length; i < len; i++) {
+        var t = typeof classes[i];
 
-  if (Array.isArray(classes) && classes.length > 0) {
-    for (var i = 0, len = classes.length; i < len; i++) {
-      var next = cc(classes[i])
-      if (next) {
-        out += (out && " ") + next
+        var next = t !== 'string' && t !== 'number' ? cc(classes[i]) : classes[i]
+        if (next) {
+          out += (out && " ") + next
+        }
       }
     }
+
   } else {
+    var type = typeof classes
+
+    if (type === "string" || type === "number") {
+      return classes || ""
+    }
+
     for (var key in classes) {
-      if (classes.hasOwnProperty(key) && classes[key]) {
+      if (classes[key]) {
         out += (out && " ") + key
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,11 @@ export default function cc(classes) {
   var out = ""
 
   if (Array.isArray(classes)) {
-    if (classes.length > 1) {
-      for (var i = 0, len = classes.length; i < len; i++) {
+    if (classes.length > 0) {
+      var i = 0;
+      var len = classes.length;
+
+      for (; i < len; i++) {
         var t = typeof classes[i];
 
         var next = t !== 'string' && t !== 'number' ? cc(classes[i]) : classes[i]
@@ -16,8 +19,10 @@ export default function cc(classes) {
   } else {
     var type = typeof classes
 
-    if (type === "string" || type === "number") {
-      return classes || ""
+    if (type === "string") {
+      return classes || "";
+    } else if(type === "number") {
+      return ""+classes;
     }
 
     for (var key in classes) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function cc(classes) {
     }
 
     for (var key in classes) {
-      if (classes[key]) {
+      if (classes.hasOwnProperty(key) && classes[key]) {
         out += (out && " ") + key
       }
     }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -10,6 +10,10 @@ test("arrays", () => {
   expect(cc(["foo", "bar", false, "baz"])).toBe("foo bar baz")
 })
 
+test("array with length 1", () => {
+  expect(cc(['foo'])).toBe('foo');
+});
+
 test("objects", () => {
   expect(
     cc({
@@ -41,3 +45,16 @@ test("not owned props", () => {
 
   delete Object.prototype.myFunction
 })
+
+test('Just a string', () => {
+  expect(cc('foo')).toBe('foo');
+});
+
+test('Just a number', () => {
+  expect(cc(21)).toBe('21');
+});
+
+test('Pass through falsy string but not 0', () => {
+  expect(cc('')).toBe('');
+  expect(cc(0)).toBe('0');
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,4 @@
-import cc from "../src"
+import cc from "../src/index.js"
 
 test("falsey", () => {
   expect(cc({})).toBe("")
@@ -38,6 +38,9 @@ test("mixed", () => {
   ).toBe("foo foo-bar foo-baz")
 })
 
+test('nested arrays', () => {
+  expect(cc(["foo", ["bar"], [["foo2", ["bar2"]]]])).toBe("foo bar foo2 bar2")
+})
 test("not owned props", () => {
   Object.prototype.myFunction = () => {}
 


### PR DESCRIPTION
By reordering some of the logic, we can optimize the function's runtime efficiency.

By doing the Array.isArray() check first, we catch the most common cases and can elide the (moderately expensive) typeof operations.  By separating the isArray() check from the length check, we can elide even more operations in the case where an empty array is passed.  We can reduce even more operations by not recursing when there are simple (string/number) types in the array and concatenating them directly.

This fork should be faster in all cases.

Here's some benchmark results (classcat = my fork, classcatNpm = as it exists now).  

```
Classcat – Strings × 9,316,220 ops/sec
ClasscatNPM – Strings × 7,874,574 ops/sec
classNames – Strings × 3,094,206 ops/sec
Fastest is Classcat – Strings

Classcat – Objects × 95,576,430 ops/sec
ClasscatNPM – Objects × 6,921,587 ops/sec
classNames – Objects × 2,897,037 ops/sec
Fastest is Classcat – Objects

Classcat – Strings & Objects × 5,738,749 ops/sec
ClasscatNPM – Strings & Objects × 5,516,302 ops/sec
classNames – Strings & Objects × 2,589,446 ops/sec
Fastest is Classcat – Strings & Objects

Classcat – Mixed × 3,374,364 ops/sec
ClasscatNPM – Mixed × 3,259,550 ops/sec
classNames – Mixed × 1,857,683 ops/sec
Fastest is Classcat – Mixed

Classcat – Arrays × 3,121,509 ops/sec
ClasscatNPM – Arrays × 2,603,359 ops/sec
classNames – Arrays × 780,863 ops/sec
Fastest is Classcat – Arrays
```


