### PR TITLE
Code cleanup and behavior fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 var isArray = Array.isArray
 
 export default function cc(obj) {
-  if (typeof obj === "string") return obj;
-  else if (typeof obj === "number") return obj.toString();
+  if (typeof obj === "string") return obj
+  else if (typeof obj === "number") return obj.toString()
 
   var out = ""
   if (isArray(obj))

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 var isArray = Array.isArray
 
 export default function cc(obj) {
+  if (typeof obj === "string") return obj;
+  else if (typeof obj === "number") return obj.toString();
+
   var out = ""
-
-  if (typeof obj === "string" || typeof obj === "number") return obj || ""
-
   if (isArray(obj))
-    for (var k = 0, tmp; k < obj.length; k++) {
-      if ((tmp = cc(obj[k])) !== "") {
+    for (var i = 0, tmp; i < obj.length; i++) {
+      if ((tmp = cc(obj[i])) !== "") {
         out += (out && " ") + tmp
       }
     }


### PR DESCRIPTION
- Method should always return strings as stated in `d.ts` (case when obj is number)
- When passing `0` value, `'0'` string should be returned
- Avoid declaring and instantiating `out` variable when not needed
- Use different variable names for `k` (keys: string) and `i` (indexes: number)