### PR TITLE
fix: add missing supported types in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export interface ClassObject {
 
 export interface ClassArray extends Array<Class> {}
 
-export type Class = string | number | ClassObject | ClassArray
+export type Class = string | number | null | undefined | ClassObject | ClassArray
 
 /**
  * @param names A string, array or object of CSS class names (as keys).


### PR DESCRIPTION
## Description

Fix #40 by adding missing `null` and `undefined` in the typings. No code change is needed as the function already supports `null` and `undefined`.