### PR TITLE
fix: add missing default function name to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,4 @@ export type Class = string | number | null | undefined | ClassObject | ClassArra
  * @param names A string, array or object of CSS class names (as keys).
  * @returns The class attribute string.
  */
-export default function (names: Class): string
+export default function cc(names: Class): string


### PR DESCRIPTION
With it cc function gets suggested by IntelliSense when typed

fixes #42 